### PR TITLE
Update interval to actually be seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Supervisor.start_link(children, strategy: :one_for_one)
 The default interval is 1 minute, and the default ttl is 1 hour, but you can configure them as you desire:
 
 ```elixir
-children = [{DVR.Cleanup, interval_seconds: 60 * 10, ttl_seconds: 60 * 60 * 24}]
+children = [{DVR.Cleanup, [[interval_seconds: 60 * 10, ttl_seconds: 60 * 60 * 24}]]]
 Supervisor.start_link(children, strategy: :one_for_one)
 ```
 

--- a/lib/dvr/cleanup.ex
+++ b/lib/dvr/cleanup.ex
@@ -6,8 +6,8 @@ defmodule DVR.Cleanup do
   use Task
   require Logger
 
-  @default_interval 60
-  @default_ttl 60 * 60
+  @default_interval 60 * 1000 # 60 seconds
+  @default_ttl 60 * 60 # 1 hour
 
   def start_link(arg) do
     Task.start_link(__MODULE__, :run, arg)
@@ -16,7 +16,7 @@ defmodule DVR.Cleanup do
   def run(), do: run([])
 
   def run(arg) do
-    interval = Keyword.get(arg, :interval_seconds) || @default_interval
+    interval = (Keyword.get(arg, :interval_seconds) * 1000) || @default_interval
     ttl = Keyword.get(arg, :ttl_seconds) || @default_ttl
 
     receive do


### PR DESCRIPTION
The current interval is milliseconds

https://hexdocs.pm/elixir/Kernel.SpecialForms.html#receive/1

    An optional after clause can be given in case the message was not received after the given timeout period, specified in milliseconds

Also updates the docs to properly pass the interval and ttl args to `Supervisor.start_link`