### PR TITLE
Allow phoenix 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule DVR.MixProject do
     [
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false},
-      {:phoenix, "~> 1.3.0", optional: true},
+      {:phoenix, "~> 1.4", optional: true},
       {:absinthe, "~> 1.4.0", optional: true},
       {:absinthe_phoenix, "~> 1.4.0", optional: true}
     ]


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix/releases/tag/v1.4.0

Now that pheonix 1.4 is out this is blocking us upgrading.